### PR TITLE
Verify purchases before closing shop

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankjs/BanksShopper/BanksShopperScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankjs/BanksShopper/BanksShopperScript.java
@@ -120,6 +120,7 @@ public class BanksShopperScript extends Script {
                                         System.out.println("Invalid action specified in config.");
                                 }
                             }
+                            if (successfullAction) Rs2Inventory.waitForInventoryChanges(2000);
                             Rs2Shop.closeShop();
                             if (successfullAction) {
                                 state = ShopperState.HOPPING;


### PR DESCRIPTION
Add a wait for inventory changes after a successful shop action to ensure items are purchased before closing the shop interface.

Previously, the shop interface was closed immediately after initiating a buy/sell action, potentially before the game server processed the transaction. This change ensures the inventory updates before the shop is closed.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7e70461-bea3-43a3-a10c-6f852d991028">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b7e70461-bea3-43a3-a10c-6f852d991028">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

